### PR TITLE
Fix bug in maxMirror

### DIFF
--- a/java/array-3/maxMirror.java
+++ b/java/array-3/maxMirror.java
@@ -14,7 +14,8 @@ public int maxMirror(int[] nums) {
                 count++;
             } else {
                 max = Math.max(max, count);
-                count = 0;
+                j += count;
+		count = 0;
             }
         }
                                                                 


### PR DESCRIPTION
Solution in maxMirror.java failed to pass the following test case:
wrong: maxMirror([1, 2, 1, 3, 2, 2, 3, 1, 2, 1, 2, 1]) -> 8
correct: maxMirror([1, 2, 1, 3, 2, 2, 3, 1, 2, 1, 2, 1]) -> 10